### PR TITLE
Fix wrong podspec name field

### DIFF
--- a/RNPushNotificationIOS.podspec
+++ b/RNPushNotificationIOS.podspec
@@ -5,7 +5,7 @@ package = JSON.parse(File.read(File.join(File.dirname(__FILE__), "package.json")
 Pod::Spec.new do |s|
   # NPM package specification
   
-  s.name           = 'RNCPushNotificationIOS'
+  s.name           = 'RNPushNotificationIOS'
   s.version        = package['version']
   s.summary        = package['description']
   s.description    = package['description']


### PR DESCRIPTION
`pod install` fails because of mismatching names:

![Capture d’écran 2019-03-22 à 11 34 31](https://user-images.githubusercontent.com/3646758/54817468-574dcd00-4c97-11e9-8374-b0a0b4cac3a4.png)
