### PR TITLE
Change $Enum to $Keys to correct flow errors

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -35,7 +35,7 @@ export type FetchResult = {
 /**
  * An event emitted by PushNotificationIOS.
  */
-export type PushNotificationEventName = $Enum<{
+export type PushNotificationEventName = $Keys<{
   /**
    * Fired when a remote notification is received. The handler will be invoked
    * with an instance of `PushNotificationIOS`.


### PR DESCRIPTION
# Summary
This is based on [Delete deprecated `$Enum<...>` utility type](https://github.com/facebook/flow/commit/764a4fb75466ab0462f63bab1a755ff3e0a6e3f9)

## Test Plan
Not required
