### PR TITLE
Use proper ES6 default export

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -450,4 +450,4 @@ class PushNotificationIOS {
   }
 }
 
-module.exports = PushNotificationIOS;
+export default PushNotificationIOS;


### PR DESCRIPTION
I was getting ESLint errors on the import statement for this package. (see [rule documentation](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/default.md).)

Technically, to use the suggested import syntax:

```js
import PushNotificationIOS from '@react-native-community/push-notification-ios';
```

the package should have an `export default`.

And since you are already using ES6 import statements, it won't harm compatibility.