### PR TITLE
Fix type and added type-check to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,10 @@ aliases:
     name: Lint
     command: yarn lint
 
+  - &tsc
+    name: TypeScript type check
+    command: yarn test:tsc
+
 # -------------------------
 #        DEFAULTS
 # -------------------------
@@ -100,6 +104,14 @@ jobs:
           at: ~/react-native-push-notification-ios
       - run: *eslint
 
+  tsc:
+    <<: *js_defaults
+    steps:
+      - attach_workspace:
+          at: ~/react-native-push-notification-ios
+      - run: *tsc
+
+
 # -------------------------
 #        WORK FLOWS
 # -------------------------
@@ -115,5 +127,8 @@ workflows:
           requires:
             - checkout-code
       - lint:
+          requires:
+            - checkout-code
+      - tsc:
           requires:
             - checkout-code

--- a/index.d.ts
+++ b/index.d.ts
@@ -261,4 +261,4 @@ export interface PushNotificationIOSStatic {
 
 declare const PushNotificationIOS: PushNotificationIOSStatic;
 
-export = PushNotificationIOS;
+export default PushNotificationIOS;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "yarn test:flow && yarn test:js",
     "test:flow": "flow check",
     "test:js": "echo 0",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test:tsc":"tsc --noEmit"
   },
   "keywords": [
     "react-native",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "noEmit": true,
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+  }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR is to address #59 

Changed type export from `export = ` to `export default`

This will fix the tsc build error for push-notification-ios

Also added type-check for CI.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test plan

yarn test:tsc

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I updated the typed files (TS and Flow)
