### PR TITLE
Fix defintion of fireDate

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,7 +61,7 @@ export interface PresentLocalNotificationDetails {
 }
 
 export interface ScheduleLocalNotificationDetails {
-  fireDate: Date;
+  fireDate: string; // Use Date.toISOString() to convert to the expected format
   alertBody: string;
   alertAction: string;
   soundName?: string;


### PR DESCRIPTION
The original PushNotificationIOS from react-native package was taking a `Date` object for `fireDate`. Using such an object with this new package however throws an exception "NSmutableDictionary cannot be converted to date".