### PR TITLE
feat: replace apple-deprecated notification method

### DIFF
--- a/ios/RNCPushNotificationIOS.h
+++ b/ios/RNCPushNotificationIOS.h
@@ -13,7 +13,7 @@ extern NSString *const RNCRemoteNotificationReceived;
 
 typedef void (^RNCRemoteNotificationCallback)(UIBackgroundFetchResult result);
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
 + (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Applying changes from this commit https://github.com/facebook/react-native/commit/edfdafc7a14e88a2660b95cb220c62f29b1b28c0

Replacing Apple-deprecated notification method with UNUserNotificationCenter.currentNotificationCenter
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

I will test this branch locally and apply changes to the example in #51 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

